### PR TITLE
Add macOS support

### DIFF
--- a/Editor/Core/PCSXReduxDownloader.cs
+++ b/Editor/Core/PCSXReduxDownloader.cs
@@ -44,6 +44,8 @@ namespace SplashEdit.EditorCode
                     return "dev-win-cli-x64"; 
                 case RuntimePlatform.LinuxEditor:
                     return "dev-linux-x64";
+                case RuntimePlatform.OSXEditor:
+                    return "dev-macos-arm";
                 default:
                     return "dev-win-cli-x64";
             }
@@ -119,7 +121,8 @@ namespace SplashEdit.EditorCode
                     Directory.Delete(installDir, true);
                 Directory.CreateDirectory(installDir);
 
-                if (Application.platform == RuntimePlatform.LinuxEditor && tempFile.EndsWith(".tar.gz"))
+                if ((Application.platform == RuntimePlatform.LinuxEditor ||
+                     Application.platform == RuntimePlatform.OSXEditor) && tempFile.EndsWith(".tar.gz"))
                 {
                     var psi = new ProcessStartInfo
                     {
@@ -140,7 +143,8 @@ namespace SplashEdit.EditorCode
 
                 // Make executable
 
-                if(Application.platform == RuntimePlatform.LinuxEditor) {
+                if(Application.platform == RuntimePlatform.LinuxEditor ||
+                   Application.platform == RuntimePlatform.OSXEditor) {
                     var psi = new ProcessStartInfo
                     {
                         FileName = "chmod",

--- a/Editor/Core/SplashControlPanel.cs
+++ b/Editor/Core/SplashControlPanel.cs
@@ -1622,9 +1622,7 @@ namespace SplashEdit.EditorCode
             var psi = new ProcessStartInfo
             {
                 FileName = Application.platform == RuntimePlatform.WindowsEditor ? "cmd.exe" : "/bin/bash",
-                Arguments = Application.platform == RuntimePlatform.WindowsEditor
-                    ? $"/c \"cd /d \"{luacDir}\" && {makeCmd}\""
-                    : $"-c \"cd \\\"{luacDir}\\\" && {makeCmd}\"",
+                Arguments = WrapCommandForMacOS(luacDir, makeCmd),
                 WorkingDirectory = luacDir,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -1737,9 +1735,7 @@ namespace SplashEdit.EditorCode
             var psi = new ProcessStartInfo
             {
                 FileName = Application.platform == RuntimePlatform.WindowsEditor ? "cmd.exe" : "/bin/bash",
-                Arguments = Application.platform == RuntimePlatform.WindowsEditor
-                    ? $"/c \"cd /d \"{nativeDir}\" && {makeCmd}\""
-                    : $"-c \"cd \\\"{nativeDir}\\\" && {makeCmd}\"",
+                Arguments = WrapCommandForMacOS(nativeDir, makeCmd),
                 WorkingDirectory = nativeDir,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -2238,6 +2234,21 @@ namespace SplashEdit.EditorCode
         // ═══════════════════════════════════════════════════════════════
         // Toolchain Detection & Install
         // ═══════════════════════════════════════════════════════════════
+
+        private static string WrapCommandForMacOS(string dir, string makeCmd)
+        {
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+                return $"/c \"cd /d \"{dir}\" && {makeCmd}\"";
+
+            string pathExport = "";
+            if (Application.platform == RuntimePlatform.OSXEditor)
+            {
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                pathExport = $"export PATH=\\\"{home}/mipsel-none-elf/bin:{home}/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\\\" && ";
+            }
+
+            return $"-c \"{pathExport}cd \\\"{dir}\\\" && {makeCmd}\"";
+        }
 
         private void RefreshToolchainStatus()
         {

--- a/Editor/ToolchainChecker.cs
+++ b/Editor/ToolchainChecker.cs
@@ -41,6 +41,24 @@ public static class ToolchainChecker
 
         try
         {
+            // macOS GUI apps have restricted PATH — check common locations directly
+            if (Application.platform == RuntimePlatform.OSXEditor)
+            {
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                string[] searchPaths = new[] {
+                    Path.Combine(home, "mipsel-none-elf", "bin"),
+                    "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"
+                };
+                string[] variants = toolName.Contains("mipsel-linux-gnu")
+                    ? new[] { toolName, toolName.Replace("mipsel-linux-gnu", "mipsel-none-elf") }
+                    : toolName.Contains("mipsel-none-elf")
+                    ? new[] { toolName, toolName.Replace("mipsel-none-elf", "mipsel-linux-gnu") }
+                    : new[] { toolName };
+                foreach (var dir in searchPaths)
+                    foreach (var variant in variants)
+                        if (File.Exists(Path.Combine(dir, variant)))
+                            return true;
+            }
             Process process = new Process
             {
                 StartInfo = new ProcessStartInfo


### PR DESCRIPTION
Adds initial macOS support for SplashEdit. Tested on Apple Silicon (M1 Max) with Unity 6000.4.

### Changes

- **Toolchain detection**: check common install paths directly on macOS since GUI apps have a restricted PATH (`/usr/bin:/bin` only). Checks `~/mipsel-none-elf/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`. Tries both `mipsel-none-elf` and `mipsel-linux-gnu` variants.
- **Build process**: inject toolchain PATH into the bash commands spawned for luac and native builds on `OSXEditor`.
- **PCSX-Redux download**: add `dev-macos-arm` platform variant so the downloader fetches the correct build instead of defaulting to Windows.

### macOS setup

Requires a MIPS cross-compiler installed manually (not auto-installed by SplashEdit):
- Homebrew: `brew tap nameloCmaS/mipsel-none-elf-gcc && brew install mipsel-none-elf-binutils mipsel-none-elf-gcc`
- Or prebuilt: [alextrevisan/mipsel-none-elf](https://github.com/alextrevisan/mipsel-none-elf)

Also requires mkpsxiso built from source: [Lameguy64/mkpsxiso](https://github.com/Lameguy64/mkpsxiso)

### Known issues

- **ISO builds**: the compiled ISO is valid and boots on emulators (BIOS recognizes it, shows the psxsplash branding), but CDROM data loading after exe handoff hangs on all macOS emulators tested (mednafen, PCSX-Redux, DuckStation). This appears to be related to the prebuilt GCC toolchain producing incorrect code for CDROM hardware register access. Emulator (PCdrv) builds work correctly.
- **PSYQo gpu.cpp assertion**: the `mipsel-none-elf` toolchain triggers an "Odd number of pixels to transfer" assertion in `psyqo/src/gpu.cpp:349`. Workaround: pad `bcr` to even instead of asserting. This is in the nugget submodule, not SplashEdit.
- **Makefile PATH**: `common.mk` and `psxlua/src/Makefile` in the nugget submodule also need PATH detection for `~/mipsel-none-elf/bin` when invoked from macOS GUI apps.