### PR TITLE
Fix odd palettes on Texture2D import

### DIFF
--- a/Runtime/PSXTexture2D.cs
+++ b/Runtime/PSXTexture2D.cs
@@ -176,7 +176,14 @@ namespace SplashEdit.RuntimeCode
             psxTex._maxColors = (int)Mathf.Pow(2, (int)bitDepth);
 
             TextureQuantizer.QuantizedResult result = TextureQuantizer.Quantize(inputTexture, psxTex._maxColors);
-
+            int targetCount = 4 - (result.Palette.Count % 4);
+            if (targetCount != 0)
+            {
+                // Align palette (CLUT) to 4 bits by padding it with a black color
+                int prevCount = result.Palette.Count;
+                result.Palette.AddRange(new Vector3[targetCount]);
+            }
+            
             foreach (Vector3 color in result.Palette)
             {
                 Color pixel = new Color(color.x, color.y, color.z);


### PR DESCRIPTION
See https://discord.com/channels/998810294220496976/1495507528551895214/1495507528551895214 for more information.

I am submitting this fix to the Github repo on behalf of RetroGameRevival/PointerFunction with permission which will fix a startup crash by checking and fixing the CLUT to align to 4 bytes, preventing the following error:

<img width="222" height="112" alt="image" src="https://github.com/user-attachments/assets/437d148d-3c61-42b2-bcf0-3136d9949cd1" />

I have tested this on a local project and can verify that it works. I had no hand in the fix itself. Discord user denpakei is responsible for the original report that led to this fix. 