### PR TITLE
Fixed Is Platform Bug

### DIFF
--- a/Runtime/PSXNavRegionBuilder.cs
+++ b/Runtime/PSXNavRegionBuilder.cs
@@ -618,7 +618,8 @@ namespace SplashEdit.RuntimeCode
                 float cx = 0, cz = 0;
                 foreach (var v in reg.vertsXZ) { cx += v.x; cz += v.y; }
                 cx /= reg.vertsXZ.Count; cz /= reg.vertsXZ.Count;
-                float cy = EvalY(reg, new Vector2(cx, cz));
+                // The -0.01f below is to compensate for floating point errors
+                float cy = EvalY(reg, new Vector2(cx, cz)) - 0.01f; 
                 Vector3 centroid = new Vector3(cx, cy, cz);
 
                 foreach (var bounds in platformBounds)


### PR DESCRIPTION
Floating point errors was causing checks to fail
<img width="306" height="78" alt="image" src="https://github.com/user-attachments/assets/16cceb02-670a-4038-a104-c944296473b6" />

Compensated for floating point error by subtracted a small value. 