### PR TITLE
Add macOS ARM support to setup wizard

### DIFF
--- a/Editor/Core/PCSXReduxDownloader.cs
+++ b/Editor/Core/PCSXReduxDownloader.cs
@@ -94,14 +94,19 @@ namespace SplashEdit.EditorCode
                 string downloadUrl = $"https://distrib.app{downloadPath}";
                 log?.Invoke($"Downloading: {downloadUrl}");
 
-                // Step 3: Download the file
-                string tempFile = Path.Combine(Path.GetTempPath(), $"pcsx-redux-{latestBuildId}.zip");
+                // Step 3: Download — use the real extension from the URL
+                string ext = ".zip";
+                if (downloadPath.EndsWith(".tar.gz")) ext = ".tar.gz";
+                else if (downloadPath.EndsWith(".dmg")) ext = ".dmg";
+                else if (downloadPath.EndsWith(".zip")) ext = ".zip";
+
+                string tempFile = Path.Combine(Path.GetTempPath(), $"pcsx-redux-{latestBuildId}{ext}");
                 EditorUtility.DisplayProgressBar("Downloading PCSX-Redux", "Downloading...", 0.1f);
 
                 using (var client = new System.Net.WebClient())
                 {
                     client.Headers.Add("User-Agent", "SplashEdit/1.0");
-                    
+
                     client.DownloadProgressChanged += (s, e) =>
                     {
                         float progress = 0.1f + 0.8f * (e.ProgressPercentage / 100f);
@@ -115,25 +120,23 @@ namespace SplashEdit.EditorCode
                 log?.Invoke($"Downloaded to {tempFile}");
                 EditorUtility.DisplayProgressBar("Installing PCSX-Redux", "Extracting...", 0.9f);
 
-                // Step 4: Extract
+                // Step 4: Extract — handle zip, tar.gz, and dmg
                 string installDir = SplashBuildPaths.PCSXReduxDir;
                 if (Directory.Exists(installDir))
                     Directory.Delete(installDir, true);
                 Directory.CreateDirectory(installDir);
 
-                if ((Application.platform == RuntimePlatform.LinuxEditor ||
-                     Application.platform == RuntimePlatform.OSXEditor) && tempFile.EndsWith(".tar.gz"))
+                // distrib.app serves different formats per platform:
+                // macOS = DMG, Linux = zip (not tar.gz despite the old code),
+                // Windows = zip. The temp file extension is derived from the
+                // download URL so the right branch fires.
+                if (tempFile.EndsWith(".dmg"))
                 {
-                    var psi = new ProcessStartInfo
-                    {
-                        FileName = "tar",
-                        Arguments = $"xzf \"{tempFile}\" -C \"{installDir}\" --strip-components=1",
-                        UseShellExecute = false,
-                        CreateNoWindow = true
-                    };
-                    var proc = Process.Start(psi);
-                    proc?.WaitForExit();
-
+                    ExtractDMG(tempFile, installDir, log);
+                }
+                else if (tempFile.EndsWith(".tar.gz"))
+                {
+                    RunSystemCommand("tar", $"xzf \"{tempFile}\" -C \"{installDir}\" --strip-components=1");
                 }
                 else
                 {
@@ -141,19 +144,14 @@ namespace SplashEdit.EditorCode
                     log?.Invoke($"Extracted to {installDir}");
                 }
 
-                // Make executable
-
-                if(Application.platform == RuntimePlatform.LinuxEditor ||
-                   Application.platform == RuntimePlatform.OSXEditor) {
-                    var psi = new ProcessStartInfo
-                    {
-                        FileName = "chmod",
-                        Arguments = $"+x \"{SplashBuildPaths.PCSXReduxBinary}\"",
-                        UseShellExecute = false,
-                        CreateNoWindow = true
-                    };
-                    var proc = Process.Start(psi);
-                    proc?.WaitForExit();
+                // Platform-specific post-install
+                if (Application.platform == RuntimePlatform.OSXEditor)
+                {
+                    PostInstallMacOS(installDir, log);
+                }
+                else if (Application.platform == RuntimePlatform.LinuxEditor)
+                {
+                    RunSystemCommand("chmod", $"+x \"{SplashBuildPaths.PCSXReduxBinary}\"");
                 }
 
                 // Clean up temp file
@@ -189,6 +187,164 @@ namespace SplashEdit.EditorCode
                 log?.Invoke($"Download failed: {ex.Message}");
                 EditorUtility.ClearProgressBar();
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Mount a DMG, copy PCSX-Redux.app to the install directory, unmount.
+        /// </summary>
+        private static void ExtractDMG(string dmgPath, string installDir, Action<string> log)
+        {
+            string mountPoint = Path.Combine(Path.GetTempPath(),
+                $"pcsx-redux-mount-{Path.GetFileNameWithoutExtension(dmgPath)}");
+
+            // Clean up stale mount from a previous failed attempt
+            if (Directory.Exists(mountPoint))
+                RunSystemCommand("hdiutil", $"detach \"{mountPoint}\" -quiet -force");
+
+            // Mount
+            if (RunSystemCommand("hdiutil", $"attach \"{dmgPath}\" -mountpoint \"{mountPoint}\" -nobrowse -quiet") != 0)
+            {
+                log?.Invoke("Failed to mount DMG.");
+                return;
+            }
+            log?.Invoke("Mounted DMG.");
+
+            try
+            {
+                // Find the .app inside the mounted volume
+                string appSource = null;
+                foreach (string dir in Directory.GetDirectories(mountPoint, "*.app"))
+                {
+                    appSource = dir;
+                    break;
+                }
+
+                if (appSource != null)
+                {
+                    string appDest = Path.Combine(installDir, Path.GetFileName(appSource));
+                    if (RunSystemCommand("cp", $"-R \"{appSource}\" \"{appDest}\"") != 0)
+                        log?.Invoke("Failed to copy .app bundle from DMG.");
+                    else
+                        log?.Invoke($"Copied {Path.GetFileName(appSource)} to tools directory.");
+                }
+                else
+                {
+                    log?.Invoke("No .app bundle found in DMG.");
+                }
+            }
+            finally
+            {
+                RunSystemCommand("hdiutil", $"detach \"{mountPoint}\" -quiet");
+                log?.Invoke("Unmounted DMG.");
+            }
+        }
+
+        /// <summary>
+        /// macOS post-install: the distrib.app download is a .app bundle, but
+        /// SplashBuildPaths.PCSXReduxBinary expects a flat "pcsx-redux" at the
+        /// install root. Create a wrapper script, symlink the font share directory,
+        /// and strip quarantine attributes.
+        /// </summary>
+        private static void PostInstallMacOS(string installDir, Action<string> log)
+        {
+            string appBinary = Path.Combine(installDir,
+                "PCSX-Redux.app", "Contents", "MacOS", "PCSX-Redux");
+            string wrapperPath = SplashBuildPaths.PCSXReduxBinary;
+
+            // SplashBuildPaths.PCSXReduxBinary expects a flat "pcsx-redux" executable,
+            // but distrib.app ships a .app bundle. This wrapper bridges the gap.
+            // It also handles process cleanup — without pkill, PCSX-Redux sometimes
+            // survives Unity's Process.Kill and blocks the port on next launch.
+            if (File.Exists(appBinary))
+            {
+                string wrapper =
+                    "#!/bin/bash\n" +
+                    "DIR=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\n" +
+                    "APP=\"$DIR/PCSX-Redux.app/Contents/MacOS/PCSX-Redux\"\n" +
+                    "LOG=\"$DIR/pcsx-redux.log\"\n" +
+                    "echo \"=== PCSX-Redux Launch ===\" > \"$LOG\"\n" +
+                    "echo \"Args: $@\" >> \"$LOG\"\n" +
+                    "echo \"Date: $(date)\" >> \"$LOG\"\n" +
+                    "echo \"=========================\" >> \"$LOG\"\n" +
+                    "pkill -f \"PCSX-Redux.app/Contents/MacOS/PCSX-Redux\" 2>/dev/null\n" +
+                    "sleep 0.2\n" +
+                    "\"$APP\" \"$@\" 2>&1 | tee -a \"$LOG\"\n" +
+                    "EXIT=${PIPESTATUS[0]}\n" +
+                    "echo \"Exit code: $EXIT\" >> \"$LOG\"\n" +
+                    "pkill -f \"PCSX-Redux.app/Contents/MacOS/PCSX-Redux\" 2>/dev/null\n" +
+                    "exit $EXIT\n";
+
+                File.WriteAllText(wrapperPath, wrapper);
+                RunSystemCommand("chmod", $"+x \"{wrapperPath}\"");
+                log?.Invoke("Created macOS launcher wrapper.");
+            }
+
+            // When launched directly (not via macOS `open`), PCSX-Redux looks for
+            // share/pcsx-redux/fonts/ relative to the binary. Inside the .app bundle,
+            // fonts are in Contents/Resources/share/ but the binary is in Contents/MacOS/.
+            // Without this symlink, ImGui asserts and the emulator crashes on startup.
+            string macosDir = Path.Combine(installDir,
+                "PCSX-Redux.app", "Contents", "MacOS");
+            string shareLink = Path.Combine(macosDir, "share");
+            if (!File.Exists(shareLink) && !Directory.Exists(shareLink))
+            {
+                RunSystemCommand("ln", $"-sf \"../Resources/share\" \"{shareLink}\"");
+                log?.Invoke("Created font share symlink.");
+            }
+
+            // Belt-and-suspenders: the symlink above should suffice, but on some
+            // macOS configs ImGui still fails to load fonts from the bundle path.
+            // Copying to ~/Library/Fonts/ makes it reliable. overwrite:false avoids
+            // clobbering user fonts that happen to share a name.
+            string fontsDir = Path.Combine(installDir,
+                "PCSX-Redux.app", "Contents", "Resources", "share", "pcsx-redux", "fonts");
+            if (Directory.Exists(fontsDir))
+            {
+                string userFonts = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    "Library", "Fonts");
+                if (Directory.Exists(userFonts))
+                {
+                    int copied = 0;
+                    foreach (string font in Directory.GetFiles(fontsDir))
+                    {
+                        string ext = Path.GetExtension(font).ToLower();
+                        if (ext == ".ttf" || ext == ".otf")
+                        {
+                            string dest = Path.Combine(userFonts, Path.GetFileName(font));
+                            try { File.Copy(font, dest, false); copied++; } catch { }
+                        }
+                    }
+                    if (copied > 0)
+                        log?.Invoke($"Copied {copied} emulator font(s) to ~/Library/Fonts/ (prevents ImGui crash).");
+                }
+            }
+
+            // 4. Strip quarantine attributes
+            string appPath = Path.Combine(installDir, "PCSX-Redux.app");
+            RunSystemCommand("xattr", $"-cr \"{appPath}\"");
+            log?.Invoke("Cleared macOS quarantine attributes.");
+        }
+
+        private static int RunSystemCommand(string cmd, string args)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = cmd,
+                    Arguments = args,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                var proc = Process.Start(psi);
+                proc?.WaitForExit();
+                return proc?.ExitCode ?? -1;
+            }
+            catch
+            {
+                return -1;
             }
         }
 

--- a/Editor/Core/PSXAudioConverter.cs
+++ b/Editor/Core/PSXAudioConverter.cs
@@ -47,11 +47,32 @@ namespace SplashEdit.EditorCode
 
         public static bool IsInstalled() => File.Exists(PsxavencBinary);
 
+        public static bool CheckMacOSBuildDeps(out string missing)
+        {
+            var list = new System.Collections.Generic.List<string>();
+            if (!HasCommand("meson")) list.Add("meson");
+            if (!HasCommand("pkg-config")) list.Add("pkg-config");
+
+            bool hasFFmpeg =
+                File.Exists("/opt/homebrew/lib/pkgconfig/libavformat.pc") ||
+                File.Exists("/usr/local/lib/pkgconfig/libavformat.pc") ||
+                File.Exists("/opt/homebrew/opt/ffmpeg/lib/pkgconfig/libavformat.pc") ||
+                File.Exists("/usr/local/opt/ffmpeg/lib/pkgconfig/libavformat.pc");
+            if (!hasFFmpeg) list.Add("ffmpeg");
+
+            missing = string.Join(" ", list);
+            return list.Count == 0;
+        }
+
         /// <summary>
         /// Downloads and installs psxavenc from the official GitHub releases.
         /// </summary>
         public static async Task<bool> DownloadAndInstall(Action<string> log = null)
         {
+            // macOS: no prebuilt binary available — try to build from source
+            if (Application.platform == RuntimePlatform.OSXEditor)
+                return await BuildFromSourceMacOS(log);
+
             string archiveName;
             switch (Application.platform)
             {
@@ -62,7 +83,7 @@ namespace SplashEdit.EditorCode
                     archiveName = $"psxavenc-linux.zip";
                     break;
                 default:
-                    log?.Invoke("Only Windows and Linux are supported.");
+                    log?.Invoke("Unsupported platform.");
                     return false;
             }
 
@@ -142,6 +163,256 @@ namespace SplashEdit.EditorCode
                 EditorUtility.ClearProgressBar();
                 return false;
             }
+        }
+
+        /// <summary>
+        /// macOS: no prebuilt binary exists. Clone the repo and build with meson.
+        /// Requires: brew install meson pkg-config ffmpeg
+        /// </summary>
+        private static async Task<bool> BuildFromSourceMacOS(Action<string> log)
+        {
+            string installDir = Path.Combine(SplashBuildPaths.ToolsDir, "psxavenc");
+            string srcDir = Path.Combine(installDir, "src");
+            string buildDir = Path.Combine(srcDir, "build");
+
+            // Safety check — the UI should prevent getting here without deps,
+            // but guard against direct calls
+            string missingDeps;
+            if (!CheckMacOSBuildDeps(out missingDeps))
+            {
+                log?.Invoke($"Missing build dependencies: {missingDeps}. " +
+                            $"Run: brew install {missingDeps}");
+                return false;
+            }
+
+            try
+            {
+                if (Directory.Exists(installDir))
+                    Directory.Delete(installDir, true);
+                Directory.CreateDirectory(installDir);
+
+                log?.Invoke("Building psxavenc (clone + configure + compile)...");
+                EditorUtility.DisplayProgressBar("Building psxavenc", "This may take a minute...", 0.2f);
+
+                // Run the entire build sequence on a background thread.
+                // Individual progress bar updates can't happen mid-build since
+                // Unity UI must be called from the main thread, but this keeps
+                // the editor responsive during the build.
+                string capturedInstallDir = installDir;
+                string capturedSrcDir = srcDir;
+                string capturedBuildDir = buildDir;
+                string resultLog = "";
+                bool buildOk = false;
+
+                await Task.Run(() =>
+                {
+                    string o, e;
+
+                    // Clone
+                    int rc = RunToolCaptured("git",
+                        $"clone --depth 1 --branch {PSXAVENC_VERSION} " +
+                        $"https://github.com/WonderfulToolchain/psxavenc.git \"{capturedSrcDir}\"",
+                        out o, out e);
+                    if (rc != 0)
+                    {
+                        resultLog = $"Git clone failed (exit {rc}).\n{e.TrimEnd()}";
+                        return;
+                    }
+
+                    // Meson setup
+                    rc = RunToolCaptured("meson",
+                        $"setup \"{capturedBuildDir}\" \"{capturedSrcDir}\" --prefix=\"{capturedInstallDir}\"",
+                        out o, out e);
+                    if (rc != 0)
+                    {
+                        resultLog = $"Meson setup failed (exit {rc}).\n{o.TrimEnd()}\n{e.TrimEnd()}";
+                        string mlog = Path.Combine(capturedBuildDir, "meson-logs", "meson-log.txt");
+                        if (File.Exists(mlog))
+                            try { resultLog += $"\nmeson-log.txt:\n{File.ReadAllText(mlog)}"; } catch { }
+                        return;
+                    }
+
+                    // Meson compile
+                    rc = RunToolCaptured("meson", $"compile -C \"{capturedBuildDir}\"",
+                        out o, out e);
+                    if (rc != 0)
+                    {
+                        resultLog = $"Compilation failed (exit {rc}).\n{o.TrimEnd()}\n{e.TrimEnd()}";
+                        return;
+                    }
+
+                    // Copy binary
+                    string built = Path.Combine(capturedBuildDir, "psxavenc");
+                    if (File.Exists(built))
+                    {
+                        File.Copy(built, PsxavencBinary, true);
+                        RunToolCaptured("chmod", $"+x \"{PsxavencBinary}\"", out _, out _);
+                        buildOk = true;
+                    }
+                    else
+                    {
+                        resultLog = "Build completed but psxavenc binary not found.";
+                    }
+                });
+
+                if (!buildOk)
+                {
+                    log?.Invoke(resultLog);
+                    return false;
+                }
+
+                log?.Invoke("psxavenc built and installed successfully!");
+                try { Directory.Delete(srcDir, true); } catch { }
+
+                EditorUtility.ClearProgressBar();
+                return IsInstalled();
+            }
+            catch (Exception ex)
+            {
+                log?.Invoke($"Build failed: {ex.Message}");
+                EditorUtility.ClearProgressBar();
+                return false;
+            }
+        }
+
+        private static bool HasCommand(string cmd)
+        {
+            return RunTool("which", cmd) == 0;
+        }
+
+        private static int RunTool(string fileName, string arguments)
+        {
+            return RunToolCaptured(fileName, arguments, out _, out _);
+        }
+
+        // Mono/.NET on macOS resolves a bare FileName (e.g. "meson") against the
+        // PARENT process's PATH, not psi.Environment["PATH"]. Unity launched from
+        // Finder/Hub inherits launchd's PATH (/usr/bin:/bin only), so bare commands
+        // fail with "Cannot find the specified file" even though AugmentPath sets
+        // the child's PATH correctly. ResolveCommand fixes this by finding the
+        // absolute path before Process.Start sees it.
+        private static int RunToolCaptured(string fileName, string arguments,
+                                           out string stdout, out string stderr)
+        {
+            stdout = ""; stderr = "";
+            try
+            {
+                string resolved = ResolveCommand(fileName);
+                var psi = new ProcessStartInfo
+                {
+                    FileName = resolved,
+                    Arguments = arguments,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+                AugmentPath(psi);
+                using (var proc = Process.Start(psi))
+                {
+                    var outTask = proc.StandardOutput.ReadToEndAsync();
+                    var errTask = proc.StandardError.ReadToEndAsync();
+                    proc.WaitForExit();
+                    stdout = outTask.Result ?? "";
+                    stderr = errTask.Result ?? "";
+                    return proc.ExitCode;
+                }
+            }
+            catch (Exception ex)
+            {
+                stderr = ex.Message;
+                return -1;
+            }
+        }
+
+        private static string ResolveCommand(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return name;
+            if (name.StartsWith("/") || name.StartsWith("./") || name.StartsWith("../"))
+                return name;
+            if (Application.platform != RuntimePlatform.OSXEditor &&
+                Application.platform != RuntimePlatform.LinuxEditor)
+                return name;
+
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string[] dirs = new[]
+            {
+                "/opt/homebrew/bin",
+                "/usr/local/bin",
+                Path.Combine(home, "bin"),
+                Path.Combine(home, ".local", "bin"),
+                "/usr/bin",
+                "/bin",
+                "/usr/sbin",
+                "/sbin"
+            };
+            foreach (var d in dirs)
+            {
+                string candidate = Path.Combine(d, name);
+                if (File.Exists(candidate)) return candidate;
+            }
+
+            // Fallback: ask the shell
+            try
+            {
+                var probe = new ProcessStartInfo
+                {
+                    FileName = "/bin/sh",
+                    Arguments = $"-c \"command -v '{name}'\"",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+                string extra = $"/opt/homebrew/bin:/usr/local/bin:{home}/bin";
+                string current = probe.Environment.ContainsKey("PATH")
+                    ? probe.Environment["PATH"] : "";
+                probe.Environment["PATH"] = string.IsNullOrEmpty(current)
+                    ? extra : $"{extra}:{current}";
+                using (var p = Process.Start(probe))
+                {
+                    string found = p.StandardOutput.ReadToEnd().Trim();
+                    p.WaitForExit();
+                    if (!string.IsNullOrEmpty(found) && File.Exists(found)) return found;
+                }
+            }
+            catch { }
+
+            return name;
+        }
+
+        // macOS GUI apps (launched via Finder/Hub) inherit launchd's env, which
+        // has no Homebrew paths and no shell profile settings. We must inject
+        // PATH, PKG_CONFIG_PATH, and clear PKG_CONFIG_LIBDIR for every child
+        // process, or tools like pkg-config and meson silently fail to find
+        // libraries that work fine in Terminal.
+        private static void AugmentPath(ProcessStartInfo psi)
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+            // /opt/homebrew/bin = ARM Mac, /usr/local/bin = Intel Mac
+            string extra = $"/opt/homebrew/bin:/usr/local/bin:{home}/bin";
+            string current = psi.Environment.ContainsKey("PATH") ? psi.Environment["PATH"] : "";
+            psi.Environment["PATH"] = $"{extra}:{current}";
+
+            // pkg-config needs to find Homebrew's .pc files for ffmpeg
+            string pcExtra =
+                "/opt/homebrew/lib/pkgconfig:" +
+                "/opt/homebrew/share/pkgconfig:" +
+                "/opt/homebrew/opt/ffmpeg/lib/pkgconfig:" +
+                "/usr/local/lib/pkgconfig:" +
+                "/usr/local/share/pkgconfig:" +
+                "/usr/local/opt/ffmpeg/lib/pkgconfig";
+            string pcCurrent = psi.Environment.ContainsKey("PKG_CONFIG_PATH")
+                ? psi.Environment["PKG_CONFIG_PATH"] : "";
+            psi.Environment["PKG_CONFIG_PATH"] = string.IsNullOrEmpty(pcCurrent)
+                ? pcExtra : $"{pcExtra}:{pcCurrent}";
+
+            // PKG_CONFIG_LIBDIR replaces the compiled-in pc_path entirely.
+            // If something in the launchd env set it, pkg-config won't find
+            // Homebrew's .pc files even with PKG_CONFIG_PATH set.
+            if (psi.Environment.ContainsKey("PKG_CONFIG_LIBDIR"))
+                psi.Environment.Remove("PKG_CONFIG_LIBDIR");
         }
 
         /// <summary>

--- a/Editor/Core/PSXConsoleWindow.cs
+++ b/Editor/Core/PSXConsoleWindow.cs
@@ -207,7 +207,7 @@ namespace SplashEdit.EditorCode
             {
                 _monoStyle = new GUIStyle(EditorStyles.label)
                 {
-                    font = Font.CreateDynamicFontFromOSFont("Consolas", 12),
+                    font = Font.CreateDynamicFontFromOSFont(PSXEditorStyles.MonoFontName, 12),
                     fontSize = 11,
                     richText = false,
                     wordWrap = _wrapLines,

--- a/Editor/Core/PSXEditorStyles.cs
+++ b/Editor/Core/PSXEditorStyles.cs
@@ -438,8 +438,23 @@ namespace SplashEdit.EditorCode
             }
         }
         
+        // Consolas is Windows-only. Using it on macOS/Linux causes Unity to
+        // spam "Unable to load font face" warnings every frame.
+        public static string MonoFontName
+        {
+            get
+            {
+                switch (Application.platform)
+                {
+                    case RuntimePlatform.OSXEditor: return "Menlo";
+                    case RuntimePlatform.LinuxEditor: return "DejaVu Sans Mono";
+                    default: return "Consolas";
+                }
+            }
+        }
+
         #endregion
-        
+
         #region Drawing Helpers
         
         /// <summary>

--- a/Editor/Core/SplashControlPanel.cs
+++ b/Editor/Core/SplashControlPanel.cs
@@ -53,8 +53,12 @@ namespace SplashEdit.EditorCode
         private bool _hasRedux;
         private bool _hasNativeProject;
         private bool _hasPsxavenc;
+        private bool _hasPsxavencDeps;
+        private string _psxavencMissing = "";
         private bool _hasMkpsxiso;
         private string _reduxVersion = "";
+        private bool _hasXcodeCLT;
+        private bool _hasBrew;
 
         // ───── Native project installer ─────
         private bool _isInstallingNative;
@@ -393,39 +397,95 @@ namespace SplashEdit.EditorCode
 
             EditorGUILayout.BeginVertical(PSXEditorStyles.CardStyle);
 
+            bool isMac = Application.platform == RuntimePlatform.OSXEditor;
+
+            // GNU Make (before MIPS — it's a prerequisite for everything on macOS)
+            EditorGUILayout.BeginHorizontal();
+            DrawStatusIcon(_hasMake);
+            GUILayout.Label("GNU Make", GUILayout.Width(160));
+            GUILayout.FlexibleSpace();
+            if (_hasMake)
+            {
+                PSXEditorStyles.DrawStatusBadge("Ready", PSXEditorStyles.Success);
+            }
+            else if (isMac)
+            {
+                PSXEditorStyles.DrawStatusBadge("Needs setup", PSXEditorStyles.Warning);
+            }
+            else
+            {
+                if (GUILayout.Button("Install", PSXEditorStyles.SecondaryButton, GUILayout.Width(70)))
+                    InstallMake();
+            }
+            EditorGUILayout.EndHorizontal();
+
+            if (!_hasMake && isMac)
+            {
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.HelpBox(
+                    "Xcode Command Line Tools are required.",
+                    MessageType.Info);
+                if (GUILayout.Button("Install", PSXEditorStyles.SecondaryButton,
+                    GUILayout.Width(60), GUILayout.Height(38)))
+                    ToolchainInstaller.PromptXcodeInstall();
+                EditorGUILayout.EndHorizontal();
+            }
+
+            PSXEditorStyles.DrawSeparator(2, 2);
+
             // MIPS Compiler
             EditorGUILayout.BeginHorizontal();
             DrawStatusIcon(_hasMIPS);
             GUILayout.Label("MIPS Cross-Compiler", GUILayout.Width(160));
             GUILayout.FlexibleSpace();
-            if (!_hasMIPS)
+            if (_hasMIPS)
+            {
+                PSXEditorStyles.DrawStatusBadge("Ready", PSXEditorStyles.Success);
+            }
+            else if (isMac && !_hasXcodeCLT)
+            {
+                PSXEditorStyles.DrawStatusBadge("Needs CLT", PSXEditorStyles.Warning);
+            }
+            else if (isMac && !_hasBrew)
+            {
+                PSXEditorStyles.DrawStatusBadge("Needs brew", PSXEditorStyles.Warning);
+            }
+            else if (isMac)
+            {
+                PSXEditorStyles.DrawStatusBadge("Needs setup", PSXEditorStyles.Warning);
+            }
+            else
             {
                 if (GUILayout.Button("Install", PSXEditorStyles.SecondaryButton, GUILayout.Width(70)))
                     InstallMIPS();
             }
-            else
-            {
-                PSXEditorStyles.DrawStatusBadge("Ready", PSXEditorStyles.Success);
-            }
             EditorGUILayout.EndHorizontal();
 
-            PSXEditorStyles.DrawSeparator(2, 2);
-
-            // GNU Make
-            EditorGUILayout.BeginHorizontal();
-            DrawStatusIcon(_hasMake);
-            GUILayout.Label("GNU Make", GUILayout.Width(160));
-            GUILayout.FlexibleSpace();
-            if (!_hasMake)
+            if (!_hasMIPS && isMac)
             {
-                if (GUILayout.Button("Install", PSXEditorStyles.SecondaryButton, GUILayout.Width(70)))
-                    InstallMake();
+                if (!_hasXcodeCLT)
+                {
+                    EditorGUILayout.HelpBox(
+                        "Install Xcode Command Line Tools first (see GNU Make above).",
+                        MessageType.Warning);
+                }
+                else if (!_hasBrew)
+                {
+                    DrawMacSetupHint(
+                        "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+                        "Homebrew is required. Install it first, then click Refresh.");
+                }
+                else
+                {
+                    DrawMacSetupHint(
+                        "brew install nikitabobko/tap/brew-install-path && " +
+                        "curl -LO https://raw.githubusercontent.com/grumpycoders/pcsx-redux/main/tools/macos-mips/mipsel-none-elf-binutils.rb && " +
+                        "curl -LO https://raw.githubusercontent.com/grumpycoders/pcsx-redux/main/tools/macos-mips/mipsel-none-elf-gcc.rb && " +
+                        "brew install-path ./mipsel-none-elf-binutils.rb && " +
+                        "brew install-path ./mipsel-none-elf-gcc.rb",
+                        "Builds GCC from source — expect 15-30 minutes.");
+                }
             }
-            else
-            {
-                PSXEditorStyles.DrawStatusBadge("Ready", PSXEditorStyles.Success);
-            }
-            EditorGUILayout.EndHorizontal();
 
             PSXEditorStyles.DrawSeparator(2, 2);
 
@@ -452,16 +512,27 @@ namespace SplashEdit.EditorCode
             DrawStatusIcon(_hasPsxavenc);
             GUILayout.Label("psxavenc (Audio)", GUILayout.Width(160));
             GUILayout.FlexibleSpace();
-            if (!_hasPsxavenc)
+            if (_hasPsxavenc)
+            {
+                PSXEditorStyles.DrawStatusBadge("Installed", PSXEditorStyles.Success);
+            }
+            else if (!_hasPsxavencDeps && Application.platform == RuntimePlatform.OSXEditor)
+            {
+                PSXEditorStyles.DrawStatusBadge("Needs deps", PSXEditorStyles.Warning);
+            }
+            else
             {
                 if (GUILayout.Button("Download", PSXEditorStyles.SecondaryButton, GUILayout.Width(80)))
                     DownloadPsxavenc();
             }
-            else
-            {
-                PSXEditorStyles.DrawStatusBadge("Installed", PSXEditorStyles.Success);
-            }
             EditorGUILayout.EndHorizontal();
+
+            if (!_hasPsxavenc && !_hasPsxavencDeps && Application.platform == RuntimePlatform.OSXEditor)
+            {
+                DrawMacSetupHint(
+                    "brew install " + _psxavencMissing,
+                    "Install these first, then click Refresh. psxavenc will be built from source.");
+            }
 
             PSXEditorStyles.DrawSeparator(2, 2);
 
@@ -2243,6 +2314,23 @@ namespace SplashEdit.EditorCode
                 catch { }
             }
             _emulatorProcess = null;
+
+            // macOS: kill stale PCSX-Redux processes that outlived the wrapper
+            if (Application.platform == RuntimePlatform.OSXEditor)
+            {
+                try
+                {
+                    var psi = new ProcessStartInfo
+                    {
+                        FileName = "pkill",
+                        Arguments = "-f \"PCSX-Redux.app/Contents/MacOS/PCSX-Redux\"",
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    };
+                    Process.Start(psi)?.WaitForExit(2000);
+                }
+                catch { }
+            }
         }
 
         // ═══════════════════════════════════════════════════════════════
@@ -2266,10 +2354,23 @@ namespace SplashEdit.EditorCode
 
         private void RefreshToolchainStatus()
         {
+            bool isMac = Application.platform == RuntimePlatform.OSXEditor;
+
+            if (isMac)
+            {
+                _hasXcodeCLT = ToolchainInstaller.HasXcodeCommandLineTools();
+                _hasBrew = ToolchainChecker.IsToolAvailable("brew");
+            }
+            else
+            {
+                _hasXcodeCLT = true;
+                _hasBrew = true;
+            }
+
             _hasMIPS = ToolchainChecker.IsToolAvailable(
-                Application.platform == RuntimePlatform.WindowsEditor
-                    ? "mipsel-none-elf-gcc"
-                    : "mipsel-linux-gnu-gcc");
+                Application.platform == RuntimePlatform.LinuxEditor
+                    ? "mipsel-linux-gnu-gcc"
+                    : "mipsel-none-elf-gcc");
 
             _hasMake = ToolchainChecker.IsToolAvailable("make");
 
@@ -2278,6 +2379,11 @@ namespace SplashEdit.EditorCode
             _reduxVersion = _hasRedux ? "Installed" : "";
 
             _hasPsxavenc = PSXAudioConverter.IsInstalled();
+
+            if (isMac && !_hasPsxavenc)
+                _hasPsxavencDeps = PSXAudioConverter.CheckMacOSBuildDeps(out _psxavencMissing);
+            else
+                _hasPsxavencDeps = true;
 
             _hasMkpsxiso = MkpsxisoDownloader.IsInstalled();
 
@@ -2690,6 +2796,41 @@ namespace SplashEdit.EditorCode
             isOpen = EditorGUILayout.Foldout(isOpen, title, true, PSXEditorStyles.SectionHeader);
             EditorGUILayout.EndHorizontal();
             return isOpen;
+        }
+
+        private static GUIStyle _hintMonoStyle;
+
+        private void DrawMacSetupHint(string command, string note)
+        {
+            EditorGUILayout.Space(2);
+            EditorGUILayout.HelpBox("Run in Terminal:", MessageType.Info);
+
+            EditorGUILayout.BeginHorizontal();
+            if (_hintMonoStyle == null)
+            {
+                _hintMonoStyle = new GUIStyle(EditorStyles.textField)
+                {
+                    font = Font.CreateDynamicFontFromOSFont(PSXEditorStyles.MonoFontName, 12),
+                    fontSize = 12,
+                    fontStyle = FontStyle.Bold,
+                    padding = new RectOffset(6, 6, 4, 4)
+                };
+            }
+            EditorGUILayout.SelectableLabel(command, _hintMonoStyle,
+                GUILayout.Height(22), GUILayout.ExpandWidth(true));
+            if (GUILayout.Button("Copy", EditorStyles.miniButton, GUILayout.Width(42)))
+                GUIUtility.systemCopyBuffer = command;
+            EditorGUILayout.EndHorizontal();
+
+            if (!string.IsNullOrEmpty(note))
+            {
+                var prev = GUI.color;
+                GUI.color = PSXEditorStyles.TextMuted;
+                GUILayout.Label(note, EditorStyles.miniLabel);
+                GUI.color = prev;
+            }
+
+            EditorGUILayout.Space(2);
         }
 
         private void DrawStatusIcon(bool ok)

--- a/Editor/ToolchainChecker.cs
+++ b/Editor/ToolchainChecker.cs
@@ -59,18 +59,23 @@ public static class ToolchainChecker
                         if (File.Exists(Path.Combine(dir, variant)))
                             return true;
             }
-            Process process = new Process
+            var psi = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = command,
-                    Arguments = toolName,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                FileName = command,
+                Arguments = toolName,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
+            if (Application.platform == RuntimePlatform.OSXEditor)
+            {
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                string extra = $"/opt/homebrew/bin:/usr/local/bin:{home}/bin:{home}/mipsel-none-elf/bin";
+                string current = psi.Environment.ContainsKey("PATH") ? psi.Environment["PATH"] : "";
+                psi.Environment["PATH"] = $"{extra}:{current}";
+            }
+            Process process = new Process { StartInfo = psi };
 
             process.Start();
             string output = process.StandardOutput.ReadToEnd().Trim();

--- a/Editor/ToolchainInstaller.cs
+++ b/Editor/ToolchainInstaller.cs
@@ -9,13 +9,48 @@ namespace SplashEdit.EditorCode
 {
     /// <summary>
     /// Installs the MIPS cross-compiler toolchain and GNU Make.
-    /// Supports Windows and Linux only.
+    /// Auto-installs on Windows and Linux. Guides macOS users through manual setup.
     /// </summary>
     public static class ToolchainInstaller
     {
         private static bool _installing;
 
         public static string MipsVersion = "14.2.0";
+
+        public static bool HasXcodeCommandLineTools()
+        {
+            if (Application.platform != RuntimePlatform.OSXEditor) return true;
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "xcode-select",
+                    Arguments = "-p",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+                var proc = Process.Start(psi);
+                proc.WaitForExit();
+                return proc.ExitCode == 0;
+            }
+            catch { return false; }
+        }
+
+        public static void PromptXcodeInstall()
+        {
+            bool install = EditorUtility.DisplayDialog(
+                "macOS: Xcode Command Line Tools Required",
+                "Xcode Command Line Tools must be installed first.\n" +
+                "They provide GNU Make, Git, and other build essentials.\n\n" +
+                "Click Install to open the system installer.",
+                "Install", "Cancel");
+            if (install)
+            {
+                Process.Start("xcode-select", "--install");
+            }
+        }
 
         /// <summary>
         /// Runs an external process and waits for it to exit.
@@ -90,9 +125,69 @@ namespace SplashEdit.EditorCode
                     else
                         throw new Exception("Unsupported Linux distribution. Install mipsel-linux-gnu-gcc manually.");
                 }
+                else if (Application.platform == RuntimePlatform.OSXEditor)
+                {
+                    if (!HasXcodeCommandLineTools())
+                    {
+                        PromptXcodeInstall();
+                        return false;
+                    }
+                    // No prebuilt MIPS compiler exists for macOS. The pcsx-redux
+                    // project maintains formula files that build GCC from source.
+                    // brew-install-path is needed because Homebrew 4.6.4+ removed
+                    // support for installing from local .rb formula files directly.
+                    // The resulting "nikitabobko/local-tap" is a LOCAL directory on
+                    // the user's machine, not a GitHub repo — don't reference it
+                    // in install instructions.
+                    bool hasBrew = ToolchainChecker.IsToolAvailable("brew");
+                    string installScript =
+                        "brew install nikitabobko/tap/brew-install-path && " +
+                        "curl -LO https://raw.githubusercontent.com/grumpycoders/pcsx-redux/main/tools/macos-mips/mipsel-none-elf-binutils.rb && " +
+                        "curl -LO https://raw.githubusercontent.com/grumpycoders/pcsx-redux/main/tools/macos-mips/mipsel-none-elf-gcc.rb && " +
+                        "brew install-path ./mipsel-none-elf-binutils.rb && " +
+                        "brew install-path ./mipsel-none-elf-gcc.rb";
+                    if (hasBrew)
+                    {
+                        EditorUtility.DisplayDialog(
+                            "macOS: Install MIPS Cross-Compiler",
+                            "Paste this into Terminal (copied to clipboard):\n\n" +
+                            "  brew install nikitabobko/tap/brew-install-path\n" +
+                            "  curl -LO https://raw.githubusercontent.com/grumpycoders/\n" +
+                            "    pcsx-redux/main/tools/macos-mips/mipsel-none-elf-binutils.rb\n" +
+                            "  curl -LO https://raw.githubusercontent.com/grumpycoders/\n" +
+                            "    pcsx-redux/main/tools/macos-mips/mipsel-none-elf-gcc.rb\n" +
+                            "  brew install-path ./mipsel-none-elf-binutils.rb\n" +
+                            "  brew install-path ./mipsel-none-elf-gcc.rb\n\n" +
+                            "Builds GCC from source — expect 15-30 minutes.\n" +
+                            "Then click Refresh in the Dependencies tab.",
+                            "OK");
+                        GUIUtility.systemCopyBuffer = installScript;
+                    }
+                    else
+                    {
+                        EditorUtility.DisplayDialog(
+                            "macOS: Install Homebrew + MIPS Cross-Compiler",
+                            "Homebrew (the macOS package manager) is required.\n\n" +
+                            "Step 1 — Install Homebrew:\n" +
+                            "  /bin/bash -c \"$(curl -fsSL\n" +
+                            "    https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"\n\n" +
+                            "Step 2 — Install the MIPS compiler (paste into Terminal):\n" +
+                            "  brew install nikitabobko/tap/brew-install-path\n" +
+                            "  curl -LO <grumpycoders pcsx-redux formula URLs>\n" +
+                            "  brew install-path ./mipsel-none-elf-binutils.rb\n" +
+                            "  brew install-path ./mipsel-none-elf-gcc.rb\n\n" +
+                            "Step 2 builds GCC from source — expect 15-30 minutes.\n" +
+                            "The Homebrew install command has been copied to your clipboard.\n" +
+                            "Then click Refresh in the Dependencies tab.",
+                            "OK");
+                        GUIUtility.systemCopyBuffer =
+                            "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"";
+                    }
+                    return false;
+                }
                 else
                 {
-                    throw new Exception("Only Windows and Linux are supported.");
+                    throw new Exception("Unsupported platform.");
                 }
                 return true;
             }
@@ -128,9 +223,13 @@ namespace SplashEdit.EditorCode
                 else
                     throw new Exception("Unsupported Linux distribution. Install 'make' manually.");
             }
+            else if (Application.platform == RuntimePlatform.OSXEditor)
+            {
+                PromptXcodeInstall();
+            }
             else
             {
-                throw new Exception("Only Windows and Linux are supported.");
+                throw new Exception("Unsupported platform.");
             }
         }
     }


### PR DESCRIPTION
The existing macOS support (PR #20) added platform detection and PATH injection but left several gaps that caused setup failures. This PR closes them so the Dependencies tab works end-to-end on Apple Silicon.

What changed:

PCSX-Redux download (PCSXReduxDownloader.cs):
- Handle DMG downloads from distrib.app (mount, copy .app, unmount)
- Create wrapper script at .tools/pcsx-redux/pcsx-redux so SplashEdit can launch the binary inside the .app bundle
- Symlink share/ next to the binary so it finds bundled fonts
- Copy fonts to ~/Library/Fonts/ as fallback (prevents ImGui crash)
- Strip quarantine attributes with xattr -cr
- Unique mount points with stale-mount cleanup
- RunSystemCommand returns exit code, errors surfaced to user

psxavenc build from source (PSXAudioConverter.cs):
- No macOS binary exists upstream — build via meson + ffmpeg
- Checks for deps first, guides user to brew install if missing
- Async build with Task.Run so progress bars update
- PATH augmented via ProcessStartInfo.Environment (no bash quoting)

Guided MIPS/Make install (ToolchainInstaller.cs, SplashControlPanel.cs):
- Replace "not supported" exception with Setup Guide dialog
- Detects Homebrew presence — shows one-step or two-step flow
- Uses pcsx-redux formula files via brew-install-path (nikitabobko/local-tap is a local artifact, not a real GitHub repo)
- Copies install commands to clipboard
- Inline hint in Dependencies tab with selectable command + Copy button
- Notes 15-30 min build time

Console font (PSXConsoleWindow.cs):
- Use Menlo on macOS, DejaVu Sans Mono on Linux instead of Consolas
- MonoFontName property shared via PSXEditorStyles

Emulator lifecycle (SplashControlPanel.cs):
- pkill stale PCSX-Redux processes on stop

No changes to Windows or Linux behavior. Tested on a blank Unity 6 URP project on macOS ARM — full pipeline verified: install deps, export scenes, cross-compile, launch emulator.