### PR TITLE
 feat: mips version check, add secondary check for linux to be able to use mipsel-none-elf version.

### DIFF
--- a/Editor/Core/SplashControlPanel.cs
+++ b/Editor/Core/SplashControlPanel.cs
@@ -2426,9 +2426,10 @@ namespace SplashEdit.EditorCode
         private void RefreshToolchainStatus()
         {
             _hasMIPS = ToolchainChecker.IsToolAvailable(
-                Application.platform == RuntimePlatform.WindowsEditor
-                    ? "mipsel-none-elf-gcc"
-                    : "mipsel-linux-gnu-gcc");
+                "mipsel-none-elf-gcc",
+                "mipsel-linux-gnu-gcc",
+                "mipsel-elf-gcc"
+            );
 
             _hasMake = ToolchainChecker.IsToolAvailable("make");
 

--- a/Editor/Core/SplashControlPanel.cs
+++ b/Editor/Core/SplashControlPanel.cs
@@ -2426,10 +2426,9 @@ namespace SplashEdit.EditorCode
         private void RefreshToolchainStatus()
         {
             _hasMIPS = ToolchainChecker.IsToolAvailable(
-                "mipsel-none-elf-gcc",
-                "mipsel-linux-gnu-gcc",
-                "mipsel-elf-gcc"
-            );
+                Application.platform == RuntimePlatform.WindowsEditor
+                    ? "mipsel-none-elf-gcc"
+                    : "mipsel-linux-gnu-gcc");
 
             _hasMake = ToolchainChecker.IsToolAvailable("make");
 

--- a/Editor/ToolchainChecker.cs
+++ b/Editor/ToolchainChecker.cs
@@ -79,6 +79,31 @@ public static class ToolchainChecker
             if (!string.IsNullOrEmpty(output))
                 return true;
 
+            // On Linux, also try the mipsel-none-elf variant if checking for mipsel-linux-gnu
+            if (Application.platform != RuntimePlatform.WindowsEditor && 
+                toolName.Contains("mipsel-linux-gnu"))
+            {
+                Process process2 = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = command,
+                        Arguments = toolName.Replace("mipsel-linux-gnu", "mipsel-none-elf"),
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    }
+                };
+                
+                process2.Start();
+                string output2 = process2.StandardOutput.ReadToEnd().Trim();
+                process2.WaitForExit();
+
+                if (!string.IsNullOrEmpty(output2))
+                    return true;
+            }
+
             // Additional fallback for MIPS tools on Windows in local MIPS path
             if (Application.platform == RuntimePlatform.WindowsEditor &&
                 toolName.StartsWith("mipsel-none-elf-"))


### PR DESCRIPTION
On Arch Linux, my currently installed mips toolchain is mipsel-none-elf-gcc. However, the dependency checker only looks for the linux specific variation if the OS is linux. The linux specific variation is missing certain C header files and compiles fail. This should fix that. 

Tested on linux version and it works. 

The change essentialy allows the linux version to see for the mipsel-linux-gnu version first, if that fails then it checks the mipsel-none-elf-gcc version. 

A better fix would be to remove os specific dependency checks in this scope when both linux and windows can have mipsel-none-elf-gcc. I will probably work on that later. 

For now the change is just making it so that we also try to look for mipsel-none-elf instead of mipsel-linux-gnu. 
Not tested on windows, mac or with mipsel-linux-gnu. Works with mipsel-none-elf