### PR TITLE
Text wrapping and alignment features to PSXUIText component / Empty for PSXObjectExporter

### DIFF
--- a/Editor/Inspectors/PSXUIEditors.cs
+++ b/Editor/Inspectors/PSXUIEditors.cs
@@ -147,8 +147,6 @@ namespace SplashEdit.EditorCode
             Color fill = new Color(0, 0, 0, selected ? 0.6f : 0.4f);
             Handles.DrawSolidRectangleWithOutline(corners, fill, borderColor);
 
-            string label = string.IsNullOrEmpty(text.DefaultText) ? "[empty]" : text.DefaultText;
-
             PSXFontAsset font = text.GetEffectiveFont();
             int glyphW = font != null ? font.GlyphWidth : 8;
             int glyphH = font != null ? font.GlyphHeight : 16;
@@ -169,42 +167,74 @@ namespace SplashEdit.EditorCode
             Color tintColor = text.TextColor;
             tintColor.a = selected ? 1f : 0.8f;
 
+            var layout = text.GetWrappedLayout(font, glyphW, glyphH, psxPixelScale, guiW);
+            float startY = guiY;
+            if (layout.BlockHeight < guiH)
+            {
+                switch (text.VerticalAlignment)
+                {
+                    case PSXTextVerticalAlignment.CenterY:
+                        startY = guiY + (guiH - layout.BlockHeight) * 0.5f;
+                        break;
+                    case PSXTextVerticalAlignment.BottomY:
+                        startY = guiY + guiH - layout.BlockHeight;
+                        break;
+                }
+            }
+
             if (font != null && font.FontTexture != null && font.SourceFont != null)
             {
                 Texture2D fontTex = font.FontTexture;
                 int glyphsPerRow = font.GlyphsPerRow;
                 float cellScreenH = glyphH * psxPixelScale;
 
-                float cursorX = guiX;
                 GUI.color = tintColor;
-                foreach (char ch in label)
+                for (int lineIndex = 0; lineIndex < layout.Lines.Length; lineIndex++)
                 {
-                    if (ch < 32 || ch > 126) continue;
-                    int charIdx = ch - 32;
-                    int col = charIdx % glyphsPerRow;
-                    int row = charIdx / glyphsPerRow;
-
-                    float advance = glyphW;
-                    if (font.AdvanceWidths != null && charIdx < font.AdvanceWidths.Length)
-                        advance = font.AdvanceWidths[charIdx];
-
-                    if (ch != ' ')
+                    string line = layout.Lines[lineIndex];
+                    float lineWidth = text.MeasureLineWidth(line, font, glyphW, psxPixelScale);
+                    float currentX = guiX;
+                    switch (text.HorizontalAlignment)
                     {
-                        float uvX = (float)(col * glyphW) / fontTex.width;
-                        float uvY = 1f - (float)((row + 1) * glyphH) / fontTex.height;
-                        float uvW = (float)glyphW / fontTex.width;
-                        float uvH = (float)glyphH / fontTex.height;
-
-                        float spriteScreenW = advance * psxPixelScale;
-                        Rect screenRect = new Rect(cursorX, guiY, spriteScreenW, cellScreenH);
-                        float uvWScaled = uvW * (advance / glyphW);
-                        Rect uvRect = new Rect(uvX, uvY, uvWScaled, uvH);
-
-                        if (screenRect.xMax > guiX && screenRect.x < guiX + guiW)
-                            GUI.DrawTextureWithTexCoords(screenRect, fontTex, uvRect);
+                        case PSXTextHorizontalAlignment.CenterX:
+                            currentX = guiX + (guiW - lineWidth) * 0.5f;
+                            break;
+                        case PSXTextHorizontalAlignment.RightX:
+                            currentX = guiX + guiW - lineWidth;
+                            break;
                     }
 
-                    cursorX += advance * psxPixelScale;
+                    float currentY = startY + lineIndex * layout.LineHeight;
+                    float cursorX = currentX;
+                    foreach (char ch in line)
+                    {
+                        if (ch < 32 || ch > 126) continue;
+                        int charIdx = ch - 32;
+                        int col = charIdx % glyphsPerRow;
+                        int row = charIdx / glyphsPerRow;
+
+                        float advance = glyphW;
+                        if (font.AdvanceWidths != null && charIdx < font.AdvanceWidths.Length)
+                            advance = font.AdvanceWidths[charIdx];
+
+                        if (ch != ' ')
+                        {
+                            float uvX = (float)(col * glyphW) / fontTex.width;
+                            float uvY = 1f - (float)((row + 1) * glyphH) / fontTex.height;
+                            float uvW = (float)glyphW / fontTex.width;
+                            float uvH = (float)glyphH / fontTex.height;
+
+                            float spriteScreenW = advance * psxPixelScale;
+                            Rect screenRect = new Rect(cursorX, currentY, spriteScreenW, cellScreenH);
+                            float uvWScaled = uvW * (advance / glyphW);
+                            Rect uvRect = new Rect(uvX, uvY, uvWScaled, uvH);
+
+                            if (screenRect.xMax > guiX && screenRect.x < guiX + guiW)
+                                GUI.DrawTextureWithTexCoords(screenRect, fontTex, uvRect);
+                        }
+
+                        cursorX += advance * psxPixelScale;
+                    }
                 }
                 GUI.color = Color.white;
             }
@@ -213,14 +243,41 @@ namespace SplashEdit.EditorCode
                 int fSize = Mathf.Clamp(Mathf.RoundToInt(glyphH * psxPixelScale * 0.75f), 6, 72);
                 GUIStyle style = new GUIStyle(EditorStyles.label);
                 style.normal.textColor = tintColor;
-                style.alignment = TextAnchor.UpperLeft;
                 style.fontSize = fSize;
                 style.wordWrap = false;
                 style.clipping = TextClipping.Clip;
 
-                Rect guiRect = new Rect(guiX, guiY, guiW, guiH);
-                GUI.color = tintColor;
-                GUI.Label(guiRect, label, style);
+                TextAnchor anchor = TextAnchor.UpperLeft;
+                switch (text.HorizontalAlignment)
+                {
+                    case PSXTextHorizontalAlignment.CenterX:
+                        anchor = TextAnchor.UpperCenter;
+                        break;
+                    case PSXTextHorizontalAlignment.RightX:
+                        anchor = TextAnchor.UpperRight;
+                        break;
+                }
+                style.alignment = anchor;
+
+                for (int lineIndex = 0; lineIndex < layout.Lines.Length; lineIndex++)
+                {
+                    string line = layout.Lines[lineIndex];
+                    float lineWidth = text.MeasureLineWidth(line, font, glyphW, psxPixelScale);
+                    float currentX = guiX;
+                    switch (text.HorizontalAlignment)
+                    {
+                        case PSXTextHorizontalAlignment.CenterX:
+                            currentX = guiX + (guiW - lineWidth) * 0.5f;
+                            break;
+                        case PSXTextHorizontalAlignment.RightX:
+                            currentX = guiX + guiW - lineWidth;
+                            break;
+                    }
+
+                    Rect guiRect = new Rect(currentX, startY + lineIndex * layout.LineHeight, lineWidth, layout.LineHeight);
+                    GUI.color = tintColor;
+                    GUI.Label(guiRect, line, style);
+                }
                 GUI.color = Color.white;
             }
             Handles.EndGUI();
@@ -418,6 +475,12 @@ namespace SplashEdit.EditorCode
                 "Text render color."));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("fontOverride"), new GUIContent("Font Override",
                 "Custom font for this text element. If empty, uses the canvas default font or built-in system font (8x16)."));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("wrapText"), new GUIContent("TextWrapped",
+                "Automatically wrap text onto additional lines when it exceeds the element width."));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("horizontalAlignment"), new GUIContent("TextXAlignment",
+                "How each wrapped line is aligned within the element bounds."));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("verticalAlignment"), new GUIContent("TextYAlignment",
+                "How the full wrapped text block is aligned within the element bounds."));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("startVisible"));
             PSXEditorStyles.EndCard();
 

--- a/Editor/PSXObjectExporterEditor.cs
+++ b/Editor/PSXObjectExporterEditor.cs
@@ -97,7 +97,7 @@ namespace SplashEdit.EditorCode
         {
             if (meshFilter == null || meshFilter.sharedMesh == null)
             {
-                EditorGUILayout.LabelField("No mesh on this object.", PSXEditorStyles.InfoBox);
+                EditorGUILayout.LabelField("No Mesh Filter or mesh was found on this object. Lua-only export is still valid, but geometry will be skipped.", PSXEditorStyles.InfoBox);
                 return;
             }
 
@@ -128,28 +128,36 @@ namespace SplashEdit.EditorCode
 
             EditorGUI.indentLevel++;
 
-            EditorGUILayout.PropertyField(bitDepthProp, new GUIContent("Bit Depth"));
-
-            EditorGUILayout.PropertyField(smoothNormalsProp, new GUIContent("Smooth Normals",
-                "Smooth normals for lighting. Disable for flat/faceted shading."));
-
-            EditorGUILayout.PropertyField(vertexColorModeProp, new GUIContent("Vertex Colors"));
-            var vcMode = (VertexColorMode)vertexColorModeProp.enumValueIndex;
-            if (vcMode == VertexColorMode.FlatColor)
+            if (meshFilter != null && meshFilter.sharedMesh != null)
             {
-                EditorGUILayout.PropertyField(flatVertexColorProp, new GUIContent("Flat Color"));
-            }
-            else if (vcMode == VertexColorMode.MeshVertexColors)
-            {
-                var exporter = target as PSXObjectExporter;
-                var mf = exporter.GetComponent<MeshFilter>();
-                if (mf != null && mf.sharedMesh != null && (mf.sharedMesh.colors == null || mf.sharedMesh.colors.Length == 0))
+                EditorGUILayout.PropertyField(bitDepthProp, new GUIContent("Bit Depth"));
+
+                EditorGUILayout.PropertyField(smoothNormalsProp, new GUIContent("Smooth Normals",
+                    "Smooth normals for lighting. Disable for flat/faceted shading."));
+
+                EditorGUILayout.PropertyField(vertexColorModeProp, new GUIContent("Vertex Colors"));
+                var vcMode = (VertexColorMode)vertexColorModeProp.enumValueIndex;
+                if (vcMode == VertexColorMode.FlatColor)
                 {
-                    EditorGUILayout.HelpBox("This mesh has no vertex colors. Will fall back to gray (128,128,128).", MessageType.Warning);
+                    EditorGUILayout.PropertyField(flatVertexColorProp, new GUIContent("Flat Color"));
                 }
+                else if (vcMode == VertexColorMode.MeshVertexColors)
+                {
+                    var exporter = target as PSXObjectExporter;
+                    var mf = exporter.GetComponent<MeshFilter>();
+                    if (mf != null && mf.sharedMesh != null && (mf.sharedMesh.colors == null || mf.sharedMesh.colors.Length == 0))
+                    {
+                        EditorGUILayout.HelpBox("This mesh has no vertex colors. Will fall back to gray (128,128,128).", MessageType.Warning);
+                    }
+                }
+
+                EditorGUILayout.PropertyField(uvOffsetMaterialProp, new GUIContent("UV Offset Material"));
+            }
+            else
+            {
+                EditorGUILayout.HelpBox("This object has no mesh. Add a Mesh Filter to use a Lua script for script-only behavior.", MessageType.Warning);
             }
 
-            EditorGUILayout.PropertyField(uvOffsetMaterialProp, new GUIContent("UV Offset Material"));
             EditorGUILayout.PropertyField(luaFileProp, new GUIContent("Lua Script"));
 
             if (luaFileProp.objectReferenceValue != null)

--- a/Runtime/PSXObjectExporter.cs
+++ b/Runtime/PSXObjectExporter.cs
@@ -19,15 +19,13 @@ namespace SplashEdit.RuntimeCode
         MeshVertexColors = 2
     }
 
-    [RequireComponent(typeof(MeshFilter))]
-    [RequireComponent(typeof(MeshRenderer))]
     [Icon("Packages/net.psxsplash.splashedit/Icons/PSXObjectExporter.png")]
     public class PSXObjectExporter : MonoBehaviour, IPSXExportable
     {
         public LuaFile LuaFile => luaFile;
 
         [FormerlySerializedAs("IsActive")]
-        [SerializeField] private bool isActive = true; 
+        [SerializeField] private bool isActive = true;
         public bool IsActive => isActive;
 
         public List<PSXTexture2D> Textures { get; set; } = new List<PSXTexture2D>();
@@ -119,6 +117,8 @@ namespace SplashEdit.RuntimeCode
         public void CreatePSXMesh(float GTEScaling)
         {
             Renderer renderer = GetComponent<Renderer>();
+            Mesh = new PSXMesh { Triangles = new List<Tri>() };
+
             if (renderer != null)
             {
                 Mesh = PSXMesh.CreateFromUnityRenderer(renderer, GTEScaling, transform, Textures, vertexColorMode, flatVertexColor, smoothNormals);

--- a/Runtime/PSXSceneWriter.cs
+++ b/Runtime/PSXSceneWriter.cs
@@ -351,7 +351,8 @@ namespace SplashEdit.RuntimeCode
                         for (int c = 0; c < 3; c++)
                             writer.Write((int)rot[r, c]);
 
-                    writer.Write((ushort)exporter.Mesh.Triangles.Count);
+                    int triangleCount = exporter.Mesh?.Triangles?.Count ?? 0;
+                    writer.Write((ushort)triangleCount);
 
                     if (exporter.LuaFile != null)
                         writer.Write((short)luaFiles.IndexOf(exporter.LuaFile));
@@ -542,9 +543,10 @@ namespace SplashEdit.RuntimeCode
                 {
                     AlignToFourBytes(writer);
                     meshOffset.DataOffsets.Add(writer.BaseStream.Position);
-                    totalFaces += exporter.Mesh.Triangles.Count;
+                    int exporterTriangleCount = exporter.Mesh?.Triangles?.Count ?? 0;
+                    totalFaces += exporterTriangleCount;
 
-                    foreach (Tri tri in exporter.Mesh.Triangles)
+                    foreach (Tri tri in exporter.Mesh?.Triangles ?? new List<Tri>())
                     {
                         // Vertex positions (3 × 6 bytes)
                         WriteVertexPosition(writer, tri.v0);
@@ -656,7 +658,7 @@ namespace SplashEdit.RuntimeCode
                         writer.Write((byte)name.Length);
                         audioNameOffsetPositions.Add(writer.BaseStream.Position);
                         writer.Write((uint)0);  // nameOffset placeholder
-                        audioClipNames.Add(name); 
+                        audioClipNames.Add(name);
                     }
 
                     // Phase 2: Write name strings (after all metadata entries)

--- a/Runtime/PSXUIText.cs
+++ b/Runtime/PSXUIText.cs
@@ -1,7 +1,23 @@
+using System.Collections.Generic;
+using System.Text;
 using UnityEngine;
 
 namespace SplashEdit.RuntimeCode
 {
+    public enum PSXTextHorizontalAlignment
+    {
+        LeftX,
+        CenterX,
+        RightX
+    }
+
+    public enum PSXTextVerticalAlignment
+    {
+        TopY,
+        CenterY,
+        BottomY
+    }
+
     /// <summary>
     /// A text UI element for PSX export.
     /// Rendered via psyqo::Font::chainprintf on PS1 hardware.
@@ -28,6 +44,23 @@ namespace SplashEdit.RuntimeCode
         [Tooltip("Custom font override. If null, uses the canvas default font (or built-in system font).")]
         [SerializeField] private PSXFontAsset fontOverride;
 
+        [Tooltip("Whether text should wrap onto additional lines when it exceeds the element width.")]
+        [SerializeField] private bool wrapText = false;
+
+        [Tooltip("Horizontal alignment of wrapped text within the element bounds.")]
+        [SerializeField] private PSXTextHorizontalAlignment horizontalAlignment = PSXTextHorizontalAlignment.LeftX;
+
+        [Tooltip("Vertical alignment of the full wrapped text block within the element bounds.")]
+        [SerializeField] private PSXTextVerticalAlignment verticalAlignment = PSXTextVerticalAlignment.TopY;
+
+        public struct WrappedTextLayout
+        {
+            public string[] Lines;
+            public float LineHeight;
+            public float BlockHeight;
+            public float MaxLineWidth;
+        }
+
         /// <summary>Element name for Lua access.</summary>
         public string ElementName => elementName;
 
@@ -46,6 +79,15 @@ namespace SplashEdit.RuntimeCode
         /// </summary>
         public PSXFontAsset FontOverride => fontOverride;
 
+        /// <summary>Whether text should automatically wrap to additional lines.</summary>
+        public bool WrapText => wrapText;
+
+        /// <summary>Horizontal alignment of wrapped text within the element bounds.</summary>
+        public PSXTextHorizontalAlignment HorizontalAlignment => horizontalAlignment;
+
+        /// <summary>Vertical alignment of the full wrapped text block within the element bounds.</summary>
+        public PSXTextVerticalAlignment VerticalAlignment => verticalAlignment;
+
         /// <summary>
         /// Resolve the effective font for this text element.
         /// Checks: fontOverride → parent PSXCanvas.DefaultFont → null (system font).
@@ -56,6 +98,112 @@ namespace SplashEdit.RuntimeCode
             PSXCanvas canvas = GetComponentInParent<PSXCanvas>();
             if (canvas != null && canvas.DefaultFont != null) return canvas.DefaultFont;
             return null; // system font
+        }
+
+        /// <summary>
+        /// Build a wrapped line layout for the current text based on the available render width.
+        /// The block height is based on the full wrapped set of lines so vertical alignment works correctly.
+        /// </summary>
+        public WrappedTextLayout GetWrappedLayout(PSXFontAsset font, int glyphWidth, int glyphHeight, float pixelScale, float containerWidth)
+        {
+            string text = string.IsNullOrEmpty(defaultText) ? "[empty]" : defaultText;
+            float lineHeight = glyphHeight * pixelScale;
+            if (containerWidth <= 0.001f)
+            {
+                return new WrappedTextLayout
+                {
+                    Lines = [text],
+                    LineHeight = lineHeight,
+                    BlockHeight = lineHeight,
+                    MaxLineWidth = MeasureLineWidth(text, font, glyphWidth, pixelScale)
+                };
+            }
+
+            var lines = new List<string>();
+            var builder = new StringBuilder();
+            float currentLineWidth = 0f;
+            float maxLineWidth = 0f;
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                char ch = text[i];
+                if (ch == '\n')
+                {
+                    if (builder.Length > 0)
+                    {
+                        lines.Add(builder.ToString());
+                        builder.Clear();
+                    }
+                    else
+                    {
+                        lines.Add(string.Empty);
+                    }
+
+                    currentLineWidth = 0f;
+                    continue;
+                }
+
+                if (ch < 32 || ch > 126)
+                    continue;
+
+                int charIdx = ch - 32;
+                float advance = glyphWidth;
+                if (font != null && font.AdvanceWidths != null && charIdx < font.AdvanceWidths.Length)
+                    advance = font.AdvanceWidths[charIdx];
+                advance *= pixelScale;
+
+                if (wrapText && builder.Length > 0 && currentLineWidth + advance > containerWidth)
+                {
+                    lines.Add(builder.ToString());
+                    builder.Clear();
+                    currentLineWidth = 0f;
+                }
+
+                builder.Append(ch);
+                currentLineWidth += advance;
+            }
+
+            if (builder.Length > 0)
+            {
+                lines.Add(builder.ToString());
+            }
+            else if (lines.Count == 0)
+            {
+                lines.Add(string.Empty);
+            }
+
+            foreach (string line in lines)
+            {
+                float lineWidth = MeasureLineWidth(line, font, glyphWidth, pixelScale);
+                if (lineWidth > maxLineWidth)
+                    maxLineWidth = lineWidth;
+            }
+
+            return new WrappedTextLayout
+            {
+                Lines = [.. lines],
+                LineHeight = lineHeight,
+                BlockHeight = Mathf.Max(lineHeight, lines.Count * lineHeight),
+                MaxLineWidth = maxLineWidth
+            };
+        }
+
+        public float MeasureLineWidth(string line, PSXFontAsset font, int glyphWidth, float pixelScale)
+        {
+            float width = 0f;
+            foreach (char ch in line)
+            {
+                if (ch < 32 || ch > 126)
+                    continue;
+
+                int charIdx = ch - 32;
+                float advance = glyphWidth;
+                if (font != null && font.AdvanceWidths != null && charIdx < font.AdvanceWidths.Length)
+                    advance = font.AdvanceWidths[charIdx];
+                width += advance * pixelScale;
+            }
+
+            return width;
         }
     }
 }


### PR DESCRIPTION
Unity visual for the time being, adds a TextWrapped bool, alongside TextXAlignment &TextYAlignment. Alignments include:
LeftX, CenterX, RightX, TopY, CenterY, BottomY.

Also added the ability to use an empty for PSXObjectExporter as to not waste tris if you need to load general scripts